### PR TITLE
Publish crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,10 @@
 name = "maco"
 version = "0.1.0"
 authors = ["naisuuuu"]
+repository = "https://github.com/naisuuuu/maco/"
 edition = "2018"
+description = "CLI tool and library used to convert manga for reading on e-ink devices."
+license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -4,3 +4,14 @@ maco is a portable cli tool used to convert comic and manga files/folders for re
 
 This project is a POC based on [mangaconv](https://github.com/naisuuuu/mangaconv) aimed to solve it's memory efficiency
 shortcomings while maintaining no runtime dependencies.
+
+## License
+
+MIT OR Apache-2.0.
+
+Wikipe-tan image used for testing by
+[Kasuga~enwiki](https://en.wikipedia.org/wiki/User:Kasuga~enwiki),
+borrowed from
+[wikimedia](https://commons.wikimedia.org/wiki/File:Wikipe-tan_at_Mother%27s_day.png)
+under
+[CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/deed.en).


### PR DESCRIPTION
This includes the changes made before publishing v0.1.0 to [crates.io](https://crates.io/crates/maco).